### PR TITLE
Adjust the available width calculation slightly to get rid of available width/height errors

### DIFF
--- a/ThunderCollection/CollectionViewController.swift
+++ b/ThunderCollection/CollectionViewController.swift
@@ -139,7 +139,7 @@ open class CollectionViewController: UICollectionViewController, UICollectionVie
     ///
     /// - Parameter indexPath: The indexPath to return the available size for.
     /// - Returns: The available room for the cell.
-    open func constrainedSize(forCellAt indexPath: IndexPath) -> CGSize {
+    open func constrainedSizeFor(cellAt indexPath: IndexPath) -> CGSize {
         
         guard let collectionView = collectionView, let collectionViewFlowLayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout else {
             return CGSize(width: view.bounds.width, height: 10000)
@@ -175,7 +175,7 @@ open class CollectionViewController: UICollectionViewController, UICollectionVie
 		
 		let row = _data[indexPath.section].items[indexPath.item]
 		
-		if let size = row.size(constrainedTo: constrainedSize(forCellAt: indexPath), in: collectionView) {
+		if let size = row.size(constrainedTo: constrainedSizeFor(cellAt: indexPath), in: collectionView) {
 			return size
 		}
 		
@@ -202,7 +202,7 @@ open class CollectionViewController: UICollectionViewController, UICollectionVie
 			guard let _cell = cell else { return .zero }
 			
 			configure(cell: _cell, with: row, at: indexPath)
-			return manualCellSize(cell: _cell)
+            return manualCellSizeFor(cell: _cell, at: indexPath)
 		}
 		
 		if cell == nil, let view = nib.instantiate(withOwner: self, options: nil).filter({ $0 as? UICollectionViewCell != nil }).first as? UICollectionViewCell {
@@ -221,7 +221,7 @@ open class CollectionViewController: UICollectionViewController, UICollectionVie
 		let mask = view.autoresizingMask
 		view.translatesAutoresizingMaskIntoConstraints = true
         
-        let cellConstrainedSize = constrainedSize(forCellAt: indexPath)
+        let cellConstrainedSize = constrainedSizeFor(cellAt: indexPath)
 		
 		if scrollDirection == .vertical {
 			
@@ -266,7 +266,9 @@ open class CollectionViewController: UICollectionViewController, UICollectionVie
 		return size ?? .zero
 	}
 
-	private func manualCellSize(cell: UICollectionViewCell) -> CGSize {
+    private func manualCellSizeFor(cell: UICollectionViewCell, at indexPath: IndexPath) -> CGSize {
+        
+        let cellConstrainedSize = constrainedSizeFor(cellAt: indexPath)
 		
 		cell.frame = CGRect(x: 0, y: 0, width: cellConstrainedSize.width, height: cellConstrainedSize.height)
 		cell.layoutSubviews()

--- a/ThunderCollection/CollectionViewController.swift
+++ b/ThunderCollection/CollectionViewController.swift
@@ -152,9 +152,11 @@ open class CollectionViewController: UICollectionViewController, UICollectionVie
 		
 		// Calculate cell height
 		if collectionViewFlowLayout.scrollDirection == .horizontal {
-			return CGSize(width: 10000, height: (insetSize.height / CGFloat(rows)) - (collectionViewFlowLayout.minimumLineSpacing * CGFloat(rows-1)))
+            let availableHeight = insetSize.height - (collectionViewFlowLayout.minimumLineSpacing * CGFloat(rows-1))
+			return CGSize(width: 10000, height: availableHeight/CGFloat(rows))
 		} else {
-			return CGSize(width: (insetSize.width / CGFloat(columns)) - (collectionViewFlowLayout.minimumInteritemSpacing * CGFloat(columns-1)), height: 10000)
+            let availableWidth = insetSize.width - (collectionViewFlowLayout.minimumInteritemSpacing * CGFloat(columns-1))
+			return CGSize(width: availableWidth/CGFloat(columns), height: 10000)
 		}
 	}
 	

--- a/ThunderCollection/CollectionViewController.swift
+++ b/ThunderCollection/CollectionViewController.swift
@@ -9,7 +9,6 @@
 import Foundation
 import UIKit
 
-@objc(TSCCollectionViewController)
 open class CollectionViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
     
     private var _data: [CollectionSectionDisplayable] = []
@@ -136,29 +135,33 @@ open class CollectionViewController: UICollectionViewController, UICollectionVie
 	
 	private var dynamicHeightCells: [String: UICollectionViewCell] = [:]
 	
-	private var cellConstrainedSize: CGSize {
-		
-		guard let collectionView = collectionView, let collectionViewFlowLayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout else {
-			return CGSize(width: view.bounds.width, height: 10000)
-		}
-
-		// Inset view.bounds by contentInset
-		var insetSize = CGSize(width: view.bounds.width - collectionView.contentInset.left - collectionView.contentInset.right, height: view.bounds.height - collectionView.contentInset.top - collectionView.contentInset.bottom)
-		
-		// Inset again by section's insets
-		let edgeInsets = collectionViewFlowLayout.sectionInset
-		insetSize.width -= (edgeInsets.left + edgeInsets.right)
-		insetSize.height -= (edgeInsets.top + edgeInsets.bottom)
-		
-		// Calculate cell height
-		if collectionViewFlowLayout.scrollDirection == .horizontal {
+    /// The size the cell at a particular indexPath has to fit within.
+    ///
+    /// - Parameter indexPath: The indexPath to return the available size for.
+    /// - Returns: The available room for the cell.
+    open func constrainedSize(forCellAt indexPath: IndexPath) -> CGSize {
+        
+        guard let collectionView = collectionView, let collectionViewFlowLayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout else {
+            return CGSize(width: view.bounds.width, height: 10000)
+        }
+        
+        // Inset view.bounds by contentInset
+        var insetSize = CGSize(width: view.bounds.width - collectionView.contentInset.left - collectionView.contentInset.right, height: view.bounds.height - collectionView.contentInset.top - collectionView.contentInset.bottom)
+        
+        // Inset again by section's insets
+        let edgeInsets = collectionViewFlowLayout.sectionInset
+        insetSize.width -= (edgeInsets.left + edgeInsets.right)
+        insetSize.height -= (edgeInsets.top + edgeInsets.bottom)
+        
+        // Calculate cell height
+        if collectionViewFlowLayout.scrollDirection == .horizontal {
             let availableHeight = insetSize.height - (collectionViewFlowLayout.minimumLineSpacing * CGFloat(rows-1))
-			return CGSize(width: 10000, height: availableHeight/CGFloat(rows))
-		} else {
+            return CGSize(width: 10000, height: availableHeight/CGFloat(rows))
+        } else {
             let availableWidth = insetSize.width - (collectionViewFlowLayout.minimumInteritemSpacing * CGFloat(columns-1))
-			return CGSize(width: availableWidth/CGFloat(columns), height: 10000)
-		}
-	}
+            return CGSize(width: availableWidth/CGFloat(columns), height: 10000)
+        }
+    }
 	
 	private var scrollDirection: UICollectionViewScrollDirection {
 		guard let flowLayout = collectionView?.collectionViewLayout as? UICollectionViewFlowLayout else {
@@ -168,11 +171,11 @@ open class CollectionViewController: UICollectionViewController, UICollectionVie
 		return flowLayout.scrollDirection
 	}
 	
-	public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+	open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
 		
 		let row = _data[indexPath.section].items[indexPath.item]
 		
-		if let size = row.size(constrainedTo: cellConstrainedSize, in: collectionView) {
+		if let size = row.size(constrainedTo: constrainedSize(forCellAt: indexPath), in: collectionView) {
 			return size
 		}
 		
@@ -217,6 +220,8 @@ open class CollectionViewController: UICollectionViewController, UICollectionVie
 		let translates = view.translatesAutoresizingMaskIntoConstraints
 		let mask = view.autoresizingMask
 		view.translatesAutoresizingMaskIntoConstraints = true
+        
+        let cellConstrainedSize = constrainedSize(forCellAt: indexPath)
 		
 		if scrollDirection == .vertical {
 			


### PR DESCRIPTION
Been working on a personal app and realised that the column/row width calculations are off slightly. This fixes it 😊 before, it was dividing the width/height by number of columns/rows respectively, and *then* removing the interim spacing. Now it removes the interim spacing first, and then divides.