### PR TITLE
Fix/cell size iphone x

### DIFF
--- a/ThunderCollection/CollectionViewController.swift
+++ b/ThunderCollection/CollectionViewController.swift
@@ -156,12 +156,14 @@ open class CollectionViewController: UICollectionViewController, UICollectionVie
         // Calculate cell height
         if collectionViewFlowLayout.scrollDirection == .horizontal {
             let availableHeight = insetSize.height - (collectionViewFlowLayout.minimumLineSpacing * CGFloat(rows-1))
-            return CGSize(width: 10000, height: availableHeight/CGFloat(rows))
-        } else {
+            // We floor this, because on odd pixel-height devices it could result in rows not being obeyed
+			return CGSize(width: 10000, height: floor(availableHeight/CGFloat(rows)))
+		} else {
             let availableWidth = insetSize.width - (collectionViewFlowLayout.minimumInteritemSpacing * CGFloat(columns-1))
-            return CGSize(width: availableWidth/CGFloat(columns), height: 10000)
-        }
-    }
+            // We floor this, because on odd pixel-width devices it could result in columns not being obeyed
+			return CGSize(width: floor(availableWidth/CGFloat(columns)), height: 10000)
+		}
+	}
 	
 	private var scrollDirection: UICollectionViewScrollDirection {
 		guard let flowLayout = collectionView?.collectionViewLayout as? UICollectionViewFlowLayout else {
@@ -194,7 +196,7 @@ open class CollectionViewController: UICollectionViewController, UICollectionVie
 			
 			if cell == nil {
 				
-				if let aClass = row.collectionCellClass as? UICollectionViewCell.Type {
+				if let aClass = row.collectionCellClass {
 					cell = aClass.init(coder: NSCoder())
 				}
 			}

--- a/ThunderCollection/CollectionViewController.swift
+++ b/ThunderCollection/CollectionViewController.swift
@@ -196,7 +196,7 @@ open class CollectionViewController: UICollectionViewController, UICollectionVie
 			
 			if cell == nil {
 				
-				if let aClass = row.collectionCellClass {
+				if let aClass = row.collectionCellClass as? UICollectionViewCell.Type {
 					cell = aClass.init(coder: NSCoder())
 				}
 			}


### PR DESCRIPTION
Due to the iPhone X having a width of 375 pts, when calculating available width with zero insets or interim spacing and `columns == 2` the collection view would be rendered as 1 column due to the width of the device being odd. This PR makes sure the width is always floored to avoid this!