### PR TITLE
Fixes single column when manually change collection view's frame

### DIFF
--- a/ThunderCollection/CollectionViewController.swift
+++ b/ThunderCollection/CollectionViewController.swift
@@ -146,7 +146,7 @@ open class CollectionViewController: UICollectionViewController, UICollectionVie
         }
         
         // Inset view.bounds by contentInset
-        var insetSize = CGSize(width: view.bounds.width - collectionView.contentInset.left - collectionView.contentInset.right, height: view.bounds.height - collectionView.contentInset.top - collectionView.contentInset.bottom)
+        var insetSize = CGSize(width: collectionView.bounds.width - collectionView.contentInset.left - collectionView.contentInset.right, height: collectionView.bounds.height - collectionView.contentInset.top - collectionView.contentInset.bottom)
         
         // Inset again by section's insets
         let edgeInsets = collectionViewFlowLayout.sectionInset


### PR DESCRIPTION
Changes the cell sizing to check the collectionView's frame  rather than the view's frame because if apps change the view's frame (Looking at you
GDPC Hazards) then this logic is broken and we end up with a single column
layout