### PR TITLE
Removed ThunderTable dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ThunderTable"]
-	path = ThunderTable
-	url = https://github.com/3sidedcube/iOS-ThunderTable.git

--- a/ThunderCollection.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ThunderCollection.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
ThunderTable itself is not referenced anywhere within the ThunderCollection framework, yet somehow was being built when using carthage - and as it was out of date (Swift 3.0) it was causing compiler errors in projects that depended on ThunderCloud.

Therefore, I've removed the git submodule and the containing folder. Now, with ThunderCloud pointing at 92fd022, it is building without error!